### PR TITLE
feat: add book listing views and csv import workflow

### DIFF
--- a/src/app/books/import/page.tsx
+++ b/src/app/books/import/page.tsx
@@ -1,0 +1,22 @@
+import { revalidatePath } from "next/cache"
+
+import { bulkInsertBooks, type BulkInsertOptions } from "@/lib/books"
+import { type PreparedBookRow } from "@/lib/csv"
+import { listShelvesWithLevels } from "@/lib/shelves"
+
+import { ImportBooksClientPage, type ImportBooksActionPayload } from "./pageClient"
+
+export default async function ImportBooksPage() {
+  const shelves = await listShelvesWithLevels()
+
+  return <ImportBooksClientPage shelves={shelves} importAction={importBooksAction} />
+}
+
+async function importBooksAction(payload: ImportBooksActionPayload) {
+  "use server"
+
+  const { rows, options } = payload
+  const result = await bulkInsertBooks(rows as PreparedBookRow[], options as BulkInsertOptions)
+  revalidatePath("/books")
+  return result
+}

--- a/src/app/books/import/pageClient.tsx
+++ b/src/app/books/import/pageClient.tsx
@@ -1,0 +1,419 @@
+"use client"
+
+import { useCallback, useMemo, useState, useTransition } from "react"
+import type { DragEvent } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  autoMapHeaders,
+  buildPreview,
+  prepareRows,
+  type CsvHeaderMapping,
+  type CsvPreviewResult,
+  type PreparedBookRow,
+} from "@/lib/csv"
+import type { ShelfWithLevels } from "@/lib/shelves"
+
+export interface ImportBooksActionPayload {
+  rows: PreparedBookRow[]
+  options: {
+    batchSize?: number
+    onDuplicate?: "skip" | "update"
+  }
+}
+
+export interface ImportBooksClientPageProps {
+  shelves: ShelfWithLevels[]
+  importAction: (payload: ImportBooksActionPayload) => Promise<{
+    okCount: number
+    errorRows: { index: number; message: string }[]
+  }>
+}
+
+const CSV_FIELD_OPTIONS = [
+  { value: "", label: "Ignore column" },
+  { value: "title", label: "Title (required)" },
+  { value: "author", label: "Author" },
+  { value: "isbn", label: "ISBN" },
+  { value: "cover_url", label: "Cover / Image" },
+  { value: "shelf", label: "Shelf" },
+  { value: "level", label: "Level" },
+  { value: "note", label: "Note" },
+] as const
+
+export function ImportBooksClientPage({ shelves, importAction }: ImportBooksClientPageProps) {
+  const [csvText, setCsvText] = useState<string>("")
+  const [fileName, setFileName] = useState<string>("")
+  const [mapping, setMapping] = useState<CsvHeaderMapping>({})
+  const [preview, setPreview] = useState<CsvPreviewResult | null>(null)
+  const [batchSize, setBatchSize] = useState(200)
+  const [onDuplicate, setOnDuplicate] = useState<"skip" | "update">("skip")
+  const [useNewShelf, setUseNewShelf] = useState(false)
+  const [newShelfName, setNewShelfName] = useState("")
+  const [selectedShelfId, setSelectedShelfId] = useState<string>("")
+  const [useNewLevel, setUseNewLevel] = useState(false)
+  const [newLevelName, setNewLevelName] = useState("")
+  const [selectedLevelId, setSelectedLevelId] = useState<string>("")
+  const [setDefaultLocation, setSetDefaultLocation] = useState(false)
+  const [resultMessage, setResultMessage] = useState<string>("")
+  const [resultErrors, setResultErrors] = useState<{ index: number; message: string }[]>([])
+  const [isPending, startTransition] = useTransition()
+
+  const levelOptions = useMemo(() => {
+    const shelf = shelves.find((item) => item.id === selectedShelfId)
+    return shelf?.levels ?? []
+  }, [selectedShelfId, shelves])
+
+  const defaultShelfName = useMemo(() => {
+    if (useNewShelf) return newShelfName.trim()
+    return shelves.find((item) => item.id === selectedShelfId)?.name ?? ""
+  }, [useNewShelf, newShelfName, selectedShelfId, shelves])
+
+  const defaultLevelName = useMemo(() => {
+    if (useNewLevel) return newLevelName.trim()
+    return levelOptions.find((level) => level.id === selectedLevelId)?.name ?? ""
+  }, [useNewLevel, newLevelName, selectedLevelId, levelOptions])
+
+  const canImport = Boolean(
+    csvText &&
+      preview &&
+      preview.rows.length > 0 &&
+      Object.values(mapping).includes("title") &&
+      preview.errors.length === 0 &&
+      (!setDefaultLocation || defaultShelfName),
+  )
+
+  const dropZoneHandlers = useDropzone((file) => {
+    void handleFile(file)
+  })
+
+  async function handleFile(file: File) {
+    const text = await file.text()
+    setFileName(file.name)
+    setCsvText(text)
+    const initialPreview = buildPreview(text)
+    const initialMapping = autoMapHeaders(initialPreview.headers)
+    setMapping(initialMapping)
+    setPreview(buildPreview(text, initialMapping))
+    setResultMessage("")
+    setResultErrors([])
+  }
+
+  function handleMappingChange(header: string, field: string) {
+    const nextMapping: CsvHeaderMapping = {
+      ...mapping,
+      [header]: (field || null) as CsvHeaderMapping[string],
+    }
+    setMapping(nextMapping)
+    if (csvText) {
+      setPreview(buildPreview(csvText, nextMapping))
+    }
+  }
+
+  async function handleImport() {
+    if (!preview || !csvText) return
+    try {
+      const rows = prepareRows(csvText, mapping, { titleCaseValues: true })
+      const normalizedRows = rows.map((row) => {
+        const next = { ...row }
+        if ((!row.shelf || !row.shelf.trim()) && setDefaultLocation && defaultShelfName) {
+          next.shelf = defaultShelfName
+        }
+        if ((!row.level || !row.level.trim()) && setDefaultLocation && defaultLevelName) {
+          next.level = defaultLevelName
+        }
+        return next
+      })
+      startTransition(() => {
+        importAction({
+          rows: normalizedRows,
+          options: { batchSize, onDuplicate },
+        }).then((result) => {
+          setResultMessage(`Imported ${result.okCount} book(s).`)
+          setResultErrors(result.errorRows)
+        })
+      })
+    } catch (error) {
+      setResultMessage(error instanceof Error ? error.message : "Failed to prepare rows")
+      setResultErrors([])
+    }
+  }
+
+  return (
+    <main className="space-y-6 px-6 py-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">Import books</h1>
+        <p className="text-muted-foreground">Upload your MyBooks.csv file to preview, map columns, and import into your bookshelf.</p>
+      </header>
+      <section
+        {...dropZoneHandlers}
+        className="flex min-h-[200px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-primary/50 bg-primary/5 p-8 text-center"
+      >
+        <p className="text-lg font-semibold">Drag & drop your CSV here</p>
+        <p className="text-sm text-muted-foreground">or click to choose a file</p>
+        <Input
+          type="file"
+          accept=".csv"
+          onChange={(event) => {
+            const file = event.target.files?.[0]
+            if (file) handleFile(file)
+          }}
+        />
+        {fileName ? <p className="text-sm text-muted-foreground">Selected: {fileName}</p> : null}
+      </section>
+
+      {preview ? (
+        <section className="space-y-4 rounded-2xl border bg-card p-6">
+          <header className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Column mapping</h2>
+            <p className="text-sm text-muted-foreground">Select how each CSV column maps to bookshelf fields.</p>
+          </header>
+          <div className="grid gap-4">
+            {preview.headers.map((header) => (
+              <div key={header} className="grid items-center gap-2 sm:grid-cols-[minmax(0,1fr)_200px]">
+                <div>
+                  <p className="font-medium">{header}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Example: {preview.rows[0]?.raw?.[header] ?? ""}
+                  </p>
+                </div>
+                <Select
+                  value={mapping[header] ?? ""}
+                  onValueChange={(value) => handleMappingChange(header, value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Ignore" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Fields</SelectLabel>
+                      {CSV_FIELD_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {preview ? (
+        <section className="space-y-4 rounded-2xl border bg-card p-6">
+          <header className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Preview (first {preview.rows.length} rows)</h2>
+            <span className="text-sm text-muted-foreground">{preview.errors.length} validation error(s)</span>
+          </header>
+          <div className="max-h-[320px] overflow-auto rounded-xl border">
+            <table className="w-full min-w-[600px] text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  {preview.headers.map((header) => (
+                    <th key={header} className="p-2 text-left font-medium">
+                      {header}
+                    </th>
+                  ))}
+                  <th className="p-2 text-left font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.rows.map((row, index) => (
+                  <tr key={index} className="border-t">
+                    {preview.headers.map((header) => (
+                      <td key={header} className="p-2 text-xs text-muted-foreground">
+                        {row.raw[header]}
+                      </td>
+                    ))}
+                    <td className="p-2 text-xs">
+                      {row.error ? (
+                        <span className="text-red-500">{row.error}</span>
+                      ) : (
+                        <span className="text-emerald-600">Ready</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {preview.errors.length ? (
+            <Textarea
+              value={preview.errors.join("\n")}
+              readOnly
+              className="min-h-[120px] text-xs"
+            />
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="space-y-4 rounded-2xl border bg-card p-6">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Shelf & level</h2>
+          <p className="text-sm text-muted-foreground">Assign imported books to an existing shelf/level or create new ones.</p>
+        </header>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Shelf</span>
+              <Button variant="ghost" size="sm" onClick={() => setUseNewShelf((prev) => !prev)}>
+                {useNewShelf ? "Use existing" : "New shelf"}
+              </Button>
+            </div>
+            {useNewShelf ? (
+              <Input
+                placeholder="New shelf name"
+                value={newShelfName}
+                onChange={(event) => setNewShelfName(event.target.value)}
+              />
+            ) : (
+              <Select value={selectedShelfId} onValueChange={setSelectedShelfId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select shelf" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Shelves</SelectLabel>
+                    {shelves.map((shelf) => (
+                      <SelectItem key={shelf.id} value={shelf.id}>
+                        {shelf.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Level</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setUseNewLevel((prev) => !prev)}
+                disabled={useNewShelf && !newShelfName}
+              >
+                {useNewLevel ? "Use existing" : "New level"}
+              </Button>
+            </div>
+            {useNewLevel ? (
+              <Input
+                placeholder="New level name"
+                value={newLevelName}
+                onChange={(event) => setNewLevelName(event.target.value)}
+              />
+            ) : (
+              <Select
+                value={selectedLevelId}
+                onValueChange={setSelectedLevelId}
+                disabled={useNewShelf ? !newShelfName : !selectedShelfId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select level" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Levels</SelectLabel>
+                    {levelOptions.map((level) => (
+                      <SelectItem key={level.id} value={level.id}>
+                        {level.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        </div>
+        <label className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Checkbox checked={setDefaultLocation} onCheckedChange={(value) => setSetDefaultLocation(Boolean(value))} />
+          Set this shelf/level as default for this import
+        </label>
+      </section>
+
+      <section className="space-y-4 rounded-2xl border bg-card p-6">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Import options</h2>
+        </header>
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="batchSize">
+              Batch size
+            </label>
+            <Input
+              id="batchSize"
+              type="number"
+              min={50}
+              max={500}
+              value={batchSize}
+              onChange={(event) => setBatchSize(Number(event.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">On duplicate ISBN</label>
+            <Select value={onDuplicate} onValueChange={(value: "skip" | "update") => setOnDuplicate(value)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="skip">Skip existing</SelectItem>
+                  <SelectItem value="update">Update title/author/cover</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <Button size="lg" disabled={!canImport || isPending} onClick={handleImport}>
+          {isPending ? "Importing…" : `Import ${preview?.rows.length ?? 0} books`}
+        </Button>
+        {resultMessage ? <p className="text-sm text-muted-foreground">{resultMessage}</p> : null}
+        {resultErrors.length ? (
+          <div className="rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            <p className="font-medium">{resultErrors.length} rows failed:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-4">
+              {resultErrors.map((error, index) => (
+                <li key={`${error.index}-${index}`}>Row {error.index + 1}: {error.message}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  )
+}
+
+function useDropzone(onFile: (file: File) => void) {
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      const file = event.dataTransfer.files?.[0]
+      if (file) onFile(file)
+    },
+    [onFile],
+  )
+
+  const handleClick = useCallback(() => {
+    // Intentionally left blank: input handles click.
+  }, [])
+
+  return {
+    onDrop: handleDrop,
+    onDragOver: (event: DragEvent<HTMLDivElement>) => event.preventDefault(),
+    onClick: handleClick,
+  }
+}

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,0 +1,36 @@
+import { listBooks, type BookStatus } from "@/lib/books"
+import { listShelvesWithLevels } from "@/lib/shelves"
+
+import { BooksClientShell } from "./pageClient"
+
+interface BooksPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>> | Record<string, string | string[] | undefined>
+}
+
+export default async function BooksPage({ searchParams }: BooksPageProps) {
+  const params = await Promise.resolve(searchParams)
+  const view = typeof params.view === "string" ? params.view : "cards"
+  const statusParam = typeof params.status === "string" ? (params.status as string) : undefined
+  const allowedStatus: BookStatus[] = ["available", "loaned", "archived"]
+  const filters = {
+    q: typeof params.q === "string" ? params.q : undefined,
+    shelf_id: typeof params.shelf_id === "string" ? params.shelf_id : undefined,
+    level_id: typeof params.level_id === "string" ? params.level_id : undefined,
+    status: statusParam && allowedStatus.includes(statusParam as BookStatus) ? (statusParam as BookStatus) : undefined,
+  }
+
+  const [{ books, total }, shelves] = await Promise.all([
+    listBooks(filters),
+    listShelvesWithLevels(),
+  ])
+
+  return (
+    <BooksClientShell
+      view={view}
+      filters={filters}
+      shelves={shelves}
+      books={books}
+      total={total}
+    />
+  )
+}

--- a/src/app/books/pageClient.tsx
+++ b/src/app/books/pageClient.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useMemo } from "react"
+
+import { BookGrid } from "@/components/books/BookGrid"
+import { BookTable } from "@/components/books/BookTable"
+import { FiltersCollapse, type FiltersState } from "@/components/books/FiltersCollapse"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { BookRecord } from "@/lib/books"
+import type { ShelfWithLevels } from "@/lib/shelves"
+
+export interface BooksClientShellProps {
+  view: string
+  filters: FiltersState
+  books: BookRecord[]
+  shelves: ShelfWithLevels[]
+  total: number
+}
+
+export function BooksClientShell({ view, filters, books, shelves, total }: BooksClientShellProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const currentView = useMemo(() => (view === "table" ? "table" : "cards"), [view])
+
+  function updateQuery(nextFilters: Partial<FiltersState & { view: string }>) {
+    const params = new URLSearchParams(searchParams?.toString() ?? "")
+    Object.entries(nextFilters).forEach(([key, value]) => {
+      if (!value) {
+        params.delete(key)
+      } else {
+        params.set(key, value)
+      }
+    })
+    const query = params.toString()
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }
+
+  return (
+    <main className="space-y-6 px-6 py-10">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">Bookshelf</h1>
+        <p className="text-muted-foreground">Manage your personal library across cards or a table view.</p>
+      </div>
+      <FiltersCollapse
+        shelves={shelves}
+        value={filters}
+        onChange={(next) => updateQuery({ ...next, view: currentView })}
+      />
+      <Tabs
+        value={currentView}
+        onValueChange={(next) => updateQuery({ view: next, ...filters })}
+        className="space-y-6"
+      >
+        <TabsList className="w-full justify-start">
+          <TabsTrigger value="cards">Cards</TabsTrigger>
+          <TabsTrigger value="table">Table</TabsTrigger>
+        </TabsList>
+        <TabsContent value="cards" className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{total} books found</span>
+          </div>
+          <BookGrid books={books} />
+        </TabsContent>
+        <TabsContent value="table" className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{total} books found</span>
+          </div>
+          <BookTable books={books} />
+        </TabsContent>
+      </Tabs>
+    </main>
+  )
+}

--- a/src/components/books/BookCard.tsx
+++ b/src/components/books/BookCard.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import Image from "next/image"
+import type { ReactNode } from "react"
+import { NotebookPen, UserRoundPlus, ArrowRightLeft } from "lucide-react"
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import type { BookRecord } from "@/lib/books"
+import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/ui"
+
+export interface BookCardProps {
+  book: BookRecord
+  className?: string
+  onTakeNotes?: (book: BookRecord) => void
+  onQuickBorrow?: (book: BookRecord) => void
+  onMoveShelf?: (book: BookRecord) => void
+}
+
+export function BookCard({
+  book,
+  className,
+  onTakeNotes,
+  onQuickBorrow,
+  onMoveShelf,
+}: BookCardProps) {
+  const fallbackCover = book.title.charAt(0).toUpperCase()
+
+  return (
+    <article
+      className={cn(
+        "group relative flex h-full flex-col gap-4 rounded-2xl border border-border/60 bg-card p-4 shadow-sm transition hover:shadow-lg",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between text-xs font-medium text-muted-foreground">
+        <span className="rounded-full bg-muted px-3 py-1 text-xs uppercase tracking-wide text-muted-foreground">
+          {book.shelf?.name ?? "Unfiled"}
+        </span>
+        {book.borrower ? (
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            Loaned to {book.borrower.full_name ?? "Unknown"}
+          </span>
+        ) : null}
+      </header>
+      <div className="aspect-[3/4] w-full overflow-hidden rounded-2xl bg-muted">
+        {book.cover_url ? (
+          <Image
+            src={book.cover_url}
+            alt={book.title}
+            width={320}
+            height={420}
+            className="h-full w-full object-cover"
+            unoptimized
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-4xl font-semibold text-muted-foreground">
+            {fallbackCover}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <h3 className="line-clamp-2 text-base font-semibold text-foreground">
+                {book.title}
+              </h3>
+            </TooltipTrigger>
+            <TooltipContent>{book.title}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        {book.author ? (
+          <p className="truncate text-sm text-muted-foreground">{book.author}</p>
+        ) : null}
+        {book.isbn ? (
+          <p className="text-xs text-muted-foreground/80">ISBN {book.isbn}</p>
+        ) : null}
+        <p className="text-xs text-muted-foreground/70">
+          Added {formatDate(book.created_at)}
+        </p>
+      </div>
+      <footer className="mt-auto flex items-center justify-center gap-3">
+        <TooltipProvider delayDuration={150}>
+          <ActionButton
+            icon={<NotebookPen className="size-5" />}
+            label="Take Notes"
+            onClick={() => onTakeNotes?.(book)}
+          />
+          <ActionButton
+            icon={<UserRoundPlus className="size-5" />}
+            label="Quick Borrow"
+            onClick={() => onQuickBorrow?.(book)}
+          />
+          <ActionButton
+            icon={<ArrowRightLeft className="size-5" />}
+            label="Move Shelf"
+            onClick={() => onMoveShelf?.(book)}
+          />
+        </TooltipProvider>
+      </footer>
+    </article>
+  )
+}
+
+interface ActionButtonProps {
+  icon: ReactNode
+  label: string
+  onClick?: () => void
+}
+
+function ActionButton({ icon, label, onClick }: ActionButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-10 w-10 rounded-full bg-background/60 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground md:h-11 md:w-11"
+          onClick={onClick}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/books/BookGrid.tsx
+++ b/src/components/books/BookGrid.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import type { BookRecord } from "@/lib/books"
+import { cn } from "@/lib/utils"
+
+import { BookCard, type BookCardProps } from "./BookCard"
+
+export interface BookGridProps {
+  books: BookRecord[]
+  className?: string
+  onTakeNotes?: BookCardProps["onTakeNotes"]
+  onQuickBorrow?: BookCardProps["onQuickBorrow"]
+  onMoveShelf?: BookCardProps["onMoveShelf"]
+}
+
+export function BookGrid({
+  books,
+  className,
+  onTakeNotes,
+  onQuickBorrow,
+  onMoveShelf,
+}: BookGridProps) {
+  if (!books.length) {
+    return (
+      <div className="rounded-xl border border-dashed p-12 text-center text-muted-foreground">
+        No books found. Try adjusting your filters.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid gap-6 sm:grid-cols-2 xl:grid-cols-3",
+        className,
+      )}
+    >
+      {books.map((book) => (
+        <BookCard
+          key={book.id}
+          book={book}
+          onTakeNotes={onTakeNotes}
+          onQuickBorrow={onQuickBorrow}
+          onMoveShelf={onMoveShelf}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/books/BookTable.tsx
+++ b/src/components/books/BookTable.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useMemo, useState } from "react"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { BookRecord } from "@/lib/books"
+import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/ui"
+
+const LOCAL_STORAGE_KEY = "bookshelf.table.columnWidths"
+
+interface ColumnConfig {
+  key: keyof BookTableWidths
+  label: string
+  minWidth: number
+}
+
+const columns: ColumnConfig[] = [
+  { key: "cover", label: "Cover", minWidth: 72 },
+  { key: "title", label: "Title", minWidth: 200 },
+  { key: "author", label: "Author", minWidth: 160 },
+  { key: "shelf", label: "Shelf/Level", minWidth: 180 },
+  { key: "isbn", label: "ISBN", minWidth: 140 },
+  { key: "status", label: "Status", minWidth: 120 },
+  { key: "created", label: "Created", minWidth: 140 },
+]
+
+export type BookTableWidths = {
+  cover: number
+  title: number
+  author: number
+  shelf: number
+  isbn: number
+  status: number
+  created: number
+}
+
+const defaultWidths: BookTableWidths = {
+  cover: 96,
+  title: 280,
+  author: 220,
+  shelf: 200,
+  isbn: 160,
+  status: 140,
+  created: 160,
+}
+
+export interface BookTableProps {
+  books: BookRecord[]
+  className?: string
+  onSelectionChange?: (ids: string[]) => void
+  selectedIds?: string[]
+}
+
+export function BookTable({ books, className, onSelectionChange, selectedIds }: BookTableProps) {
+  const [columnWidths, setColumnWidths] = useState<BookTableWidths>(defaultWidths)
+  const [internalSelection, setInternalSelection] = useState<string[]>([])
+  const selection = selectedIds ?? internalSelection
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY)
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setColumnWidths({ ...defaultWidths, ...parsed })
+      } catch (error) {
+        console.warn("Failed to parse stored column widths", error)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    setInternalSelection((prev) => prev.filter((id) => books.some((book) => book.id === id)))
+  }, [books])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(columnWidths))
+  }, [columnWidths])
+
+  function updateSelection(next: string[]) {
+    if (!selectedIds) {
+      setInternalSelection(next)
+    }
+    onSelectionChange?.(next)
+  }
+
+  const isAllSelected = useMemo(() => selection.length > 0 && selection.length === books.length, [selection, books])
+
+  function toggleAll(checked: boolean | "indeterminate") {
+    if (checked) {
+      updateSelection(books.map((book) => book.id))
+    } else {
+      updateSelection([])
+    }
+  }
+
+  function toggleRow(id: string, checked: boolean | "indeterminate") {
+    if (checked) {
+      updateSelection(Array.from(new Set([...selection, id])))
+    } else {
+      updateSelection(selection.filter((value) => value !== id))
+    }
+  }
+
+  function startResize(column: ColumnConfig, startX: number) {
+    const initialWidth = columnWidths[column.key]
+    function handleMove(event: MouseEvent) {
+      const delta = event.clientX - startX
+      setColumnWidths((prev) => ({
+        ...prev,
+        [column.key]: Math.max(column.minWidth, initialWidth + delta),
+      }))
+    }
+    function handleUp() {
+      window.removeEventListener("mousemove", handleMove)
+      window.removeEventListener("mouseup", handleUp)
+    }
+    window.addEventListener("mousemove", handleMove)
+    window.addEventListener("mouseup", handleUp)
+  }
+
+  if (!books.length) {
+    return (
+      <div className="rounded-xl border border-dashed p-12 text-center text-muted-foreground">
+        No books found. Try adjusting your filters.
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("rounded-xl border", className)}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">
+              <Checkbox
+                aria-label="Select all"
+                checked={isAllSelected}
+                onCheckedChange={toggleAll}
+              />
+            </TableHead>
+            {columns.map((column) => (
+              <TableHead key={column.key} style={{ width: columnWidths[column.key] }}>
+                <div className="flex items-center justify-between gap-3">
+                  <span>{column.label}</span>
+                  <span
+                    className="h-6 w-1 cursor-col-resize rounded-full bg-border"
+                    onMouseDown={(event) => startResize(column, event.clientX)}
+                  />
+                </div>
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {books.map((book) => {
+            const checked = selection.includes(book.id)
+            return (
+              <TableRow key={book.id} data-state={checked ? "selected" : undefined}>
+                <TableCell>
+                  <Checkbox
+                    aria-label={`Select ${book.title}`}
+                    checked={checked}
+                    onCheckedChange={(value) => toggleRow(book.id, value)}
+                  />
+                </TableCell>
+                <TableCell style={{ width: columnWidths.cover }}>
+                  <div className="flex items-center">
+                    <div className="h-16 w-12 overflow-hidden rounded-lg bg-muted">
+                      {book.cover_url ? (
+                        <Image
+                          src={book.cover_url}
+                          alt={book.title}
+                          width={64}
+                          height={96}
+                          className="h-full w-full object-cover"
+                          unoptimized
+                        />
+                      ) : (
+                        <span className="flex h-full w-full items-center justify-center text-sm font-semibold text-muted-foreground">
+                          {book.title.charAt(0).toUpperCase()}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.title }}>
+                  <div className="flex flex-col">
+                    <span className="font-medium text-foreground">{book.title}</span>
+                    {book.level?.name ? (
+                      <span className="text-xs text-muted-foreground">Level {book.level.name}</span>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.author }}>
+                  <span className="text-muted-foreground">{book.author ?? "—"}</span>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.shelf }}>
+                  <div className="flex flex-col">
+                    <span>{book.shelf?.name ?? "Unfiled"}</span>
+                    {book.level?.name ? <span className="text-xs text-muted-foreground">{book.level.name}</span> : null}
+                  </div>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.isbn }}>
+                  <span>{book.isbn ?? "—"}</span>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.status }}>
+                  <span
+                    className={cn(
+                      "rounded-full px-3 py-1 text-xs font-semibold",
+                      book.status === "loaned"
+                        ? "bg-amber-100 text-amber-800"
+                        : book.status === "archived"
+                          ? "bg-slate-200 text-slate-700"
+                          : "bg-emerald-100 text-emerald-700",
+                    )}
+                  >
+                    {book.status ? book.status.replace(/_/g, " ") : "Available"}
+                  </span>
+                </TableCell>
+                <TableCell style={{ width: columnWidths.created }}>
+                  <span className="text-muted-foreground">{formatDate(book.created_at)}</span>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/src/components/books/FiltersCollapse.tsx
+++ b/src/components/books/FiltersCollapse.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { BookStatus } from "@/lib/books"
+import type { ShelfWithLevels } from "@/lib/shelves"
+import { cn } from "@/lib/utils"
+
+export interface FiltersState {
+  q?: string
+  shelf_id?: string
+  level_id?: string
+  status?: BookStatus
+}
+
+export interface FiltersCollapseProps {
+  shelves: ShelfWithLevels[]
+  value: FiltersState
+  onChange: (value: FiltersState) => void
+  className?: string
+}
+
+export function FiltersCollapse({ shelves, value, onChange, className }: FiltersCollapseProps) {
+  const [open, setOpen] = useState(true)
+
+  const levelOptions = useMemo(() => {
+    const selectedShelf = shelves.find((shelf) => shelf.id === value.shelf_id)
+    return selectedShelf?.levels ?? []
+  }, [shelves, value.shelf_id])
+
+  function update(partial: Partial<FiltersState>) {
+    onChange({ ...value, ...partial })
+  }
+
+  function reset() {
+    onChange({})
+  }
+
+  return (
+    <section className={cn("rounded-xl border bg-card", className)}>
+      <header className="flex items-center justify-between px-5 py-4">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Filters</h2>
+          <p className="text-xs text-muted-foreground">Search by keyword or narrow by shelf, level, or status.</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={() => setOpen((prev) => !prev)}>
+          {open ? "Collapse" : "Expand"}
+        </Button>
+      </header>
+      {open ? (
+        <div className="flex flex-col gap-4 px-5 pb-5">
+          <Input
+            placeholder="Search title, author, or ISBN"
+            value={value.q ?? ""}
+            onChange={(event) => update({ q: event.target.value })}
+          />
+          <div className="grid gap-4 md:grid-cols-3">
+            <Select
+              value={value.shelf_id ?? "__all__"}
+              onValueChange={(next) =>
+                update({ shelf_id: next === "__all__" ? undefined : next, level_id: undefined })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All shelves" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Shelves</SelectLabel>
+                  <SelectItem value="__all__">All shelves</SelectItem>
+                  {shelves.map((shelf) => (
+                    <SelectItem key={shelf.id} value={shelf.id}>
+                      {shelf.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Select
+              value={value.level_id ?? "__all__"}
+              onValueChange={(next) =>
+                update({ level_id: next === "__all__" ? undefined : next })
+              }
+              disabled={!levelOptions.length}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All levels" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Levels</SelectLabel>
+                  <SelectItem value="__all__">All levels</SelectItem>
+                  {levelOptions.map((level) => (
+                    <SelectItem key={level.id} value={level.id}>
+                      {level.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Select
+              value={value.status ?? "__all__"}
+              onValueChange={(next) =>
+                update({ status: next === "__all__" ? undefined : (next as BookStatus) })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Status</SelectLabel>
+                  <SelectItem value="__all__">All statuses</SelectItem>
+                  <SelectItem value="available">Available</SelectItem>
+                  <SelectItem value="loaned">Loaned</SelectItem>
+                  <SelectItem value="archived">Archived</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="text-xs text-muted-foreground">{summarizeFilters(value, shelves)}</span>
+            <Button variant="outline" size="sm" onClick={reset}>
+              Clear all
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function summarizeFilters(filters: FiltersState, shelves: ShelfWithLevels[]) {
+  const active: string[] = []
+  if (filters.q) active.push(`Search: "${filters.q}"`)
+  if (filters.shelf_id) {
+    const shelf = shelves.find((item) => item.id === filters.shelf_id)
+    if (shelf) active.push(`Shelf: ${shelf.name}`)
+  }
+  if (filters.level_id) {
+    const level = shelves
+      .flatMap((shelf) => shelf.levels.map((level) => ({ ...level, shelf_name: shelf.name })))
+      .find((level) => level.id === filters.level_id)
+    if (level) active.push(`Level: ${level.name}`)
+  }
+  if (filters.status) active.push(`Status: ${filters.status}`)
+  return active.length ? active.join(" · ") : "No filters applied"
+}

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+export interface ConfirmDialogProps {
+  title?: string
+  description?: string
+  confirmText?: string
+  cancelText?: string
+  onConfirm?: () => Promise<void> | void
+  trigger: React.ReactNode
+}
+
+export function ConfirmDialog({
+  title = "Are you sure?",
+  description = "This action cannot be undone.",
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  onConfirm,
+  trigger,
+}: ConfirmDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  async function handleConfirm() {
+    try {
+      setBusy(true)
+      await onConfirm?.()
+      setOpen(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <span onClick={() => setOpen(true)} className="inline-flex">
+        {trigger}
+      </span>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={busy}>
+            {cancelText}
+          </Button>
+          <Button onClick={handleConfirm} disabled={busy}>
+            {confirmText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,0 +1,291 @@
+import { chunk } from "./collections"
+import { PreparedBookRow } from "./csv"
+import { createServerSupabaseClient, isSupabaseConfigured } from "./supabaseClient"
+
+export type BookStatus = "available" | "loaned" | "archived"
+
+export interface BookRecord {
+  id: string
+  title: string
+  author?: string | null
+  isbn?: string | null
+  cover_url?: string | null
+  status?: BookStatus | null
+  created_at?: string
+  shelf?: { id: string; name: string } | null
+  level?: { id: string; name: string } | null
+  borrower?: { id: string; full_name?: string | null } | null
+  loan?: { id: string; due_at?: string | null } | null
+}
+
+export interface ListBooksParams {
+  q?: string
+  shelf_id?: string
+  level_id?: string
+  status?: BookStatus
+  limit?: number
+  offset?: number
+}
+
+export interface ListBooksResult {
+  books: BookRecord[]
+  total: number
+}
+
+export async function listBooks(params: ListBooksParams = {}): Promise<ListBooksResult> {
+  const { q, shelf_id, level_id, status, limit = 24, offset = 0 } = params
+  if (!isSupabaseConfigured()) {
+    return { books: [], total: 0 }
+  }
+  const supabase = createServerSupabaseClient()
+
+  try {
+    let query = supabase
+      .from("books")
+      .select(
+        "id,title,author,isbn,cover_url,status,created_at,shelves!books_shelf_id_fkey(id,name),shelf_levels!books_shelf_level_id_fkey(id,name),borrowers!books_borrower_id_fkey(id,full_name),loans(id,due_at)",
+        { count: "exact" },
+      )
+      .order("created_at", { ascending: false })
+      .limit(limit)
+      .range(offset, offset + limit - 1)
+
+    if (q) {
+      const escaped = q.replace(/[,]/g, "")
+      query = query.or(
+        `title.ilike.%${escaped}%,author.ilike.%${escaped}%,isbn.ilike.%${escaped}%`,
+        { referencedTable: "books" },
+      )
+    }
+
+    if (shelf_id) {
+      query = query.eq("shelf_id", shelf_id)
+    }
+    if (level_id) {
+      query = query.eq("shelf_level_id", level_id)
+    }
+    if (status) {
+      query = query.eq("status", status)
+    }
+
+    const { data, error, count } = await query
+    if (error) {
+      console.warn("Failed to fetch books", error)
+      return { books: [], total: 0 }
+    }
+
+    const rawRows = (data ?? []) as Record<string, unknown>[]
+    const books: BookRecord[] = rawRows.map((row) => {
+      const typed = row as unknown as SupabaseBookRow
+      const shelf = typed.shelves as SupabaseBookRow["shelves"]
+      const level = typed.shelf_levels as SupabaseBookRow["shelf_levels"]
+      const borrower = typed.borrowers as SupabaseBookRow["borrowers"]
+      const loan = typed.loans as SupabaseBookRow["loans"]
+
+      return {
+        id: typed.id,
+        title: typed.title,
+        author: typed.author ?? null,
+        isbn: typed.isbn ?? null,
+        cover_url: typed.cover_url ?? null,
+        status: typed.status ?? null,
+        created_at: typed.created_at,
+        shelf: shelf ? { id: shelf.id, name: shelf.name } : null,
+        level: level ? { id: level.id, name: level.name } : null,
+        borrower: borrower ? { id: borrower.id, full_name: borrower.full_name } : null,
+        loan: loan ? { id: loan.id, due_at: loan.due_at } : null,
+      } satisfies BookRecord
+    })
+
+    return {
+      books,
+      total: count ?? books.length,
+    }
+  } catch (error) {
+    console.warn("Failed to load books", error)
+    return { books: [], total: 0 }
+  }
+}
+
+export interface BulkInsertOptions {
+  batchSize?: number
+  onDuplicate?: "skip" | "update"
+}
+
+export interface BulkInsertErrorRow {
+  index: number
+  message: string
+}
+
+export interface BulkInsertResult {
+  okCount: number
+  errorRows: BulkInsertErrorRow[]
+}
+
+interface SupabaseBookRow {
+  id: string
+  title: string
+  author?: string | null
+  isbn?: string | null
+  cover_url?: string | null
+  status?: BookStatus | null
+  created_at?: string
+  shelves?: { id: string; name: string } | null
+  shelf_levels?: { id: string; name: string } | null
+  borrowers?: { id: string; full_name?: string | null } | null
+  loans?: { id: string; due_at?: string | null } | null
+}
+
+interface BookInsertPayload {
+  title: string
+  author?: string | null
+  isbn?: string | null
+  cover_url?: string | null
+  shelf_id?: string | null
+  shelf_level_id?: string | null
+  note?: string | null
+}
+
+interface ShelfCacheValue {
+  shelf_id: string
+  shelf_level_id?: string | null
+}
+
+async function ensureShelfAndLevel(
+  supabase: ReturnType<typeof createServerSupabaseClient>,
+  shelfName?: string | null,
+  levelName?: string | null,
+  cache = new Map<string, ShelfCacheValue>(),
+): Promise<ShelfCacheValue | null> {
+  if (!shelfName) return null
+  const key = `${shelfName.toLowerCase()}::${levelName?.toLowerCase() ?? ""}`
+  if (cache.has(key)) {
+    return cache.get(key) ?? null
+  }
+
+  const { data: existingShelf, error: shelfError } = await supabase
+    .from("shelves")
+    .select("id")
+    .eq("name", shelfName)
+    .maybeSingle()
+  if (shelfError && shelfError.code !== "PGRST116") {
+    throw new Error(shelfError.message)
+  }
+  let shelfId = existingShelf?.id
+  if (!shelfId) {
+    const { data: insertedShelf, error: insertShelfError } = await supabase
+      .from("shelves")
+      .insert({ name: shelfName })
+      .select("id")
+      .single()
+    if (insertShelfError) {
+      throw new Error(insertShelfError.message)
+    }
+    shelfId = insertedShelf.id
+  }
+
+  if (!levelName) {
+    const result = { shelf_id: shelfId, shelf_level_id: null }
+    cache.set(key, result)
+    return result
+  }
+
+  const { data: existingLevel, error: levelError } = await supabase
+    .from("shelf_levels")
+    .select("id")
+    .eq("shelf_id", shelfId)
+    .eq("name", levelName)
+    .maybeSingle()
+  if (levelError && levelError.code !== "PGRST116") {
+    throw new Error(levelError.message)
+  }
+
+  let levelId = existingLevel?.id
+  if (!levelId) {
+    const { data: insertedLevel, error: insertLevelError } = await supabase
+      .from("shelf_levels")
+      .insert({ shelf_id: shelfId, name: levelName })
+      .select("id")
+      .single()
+    if (insertLevelError) {
+      throw new Error(insertLevelError.message)
+    }
+    levelId = insertedLevel.id
+  }
+
+  const result = { shelf_id: shelfId, shelf_level_id: levelId }
+  cache.set(key, result)
+  return result
+}
+
+export async function bulkInsertBooks(
+  rows: PreparedBookRow[],
+  options: BulkInsertOptions = {},
+): Promise<BulkInsertResult> {
+  if (!isSupabaseConfigured()) {
+    throw new Error("Supabase is not configured")
+  }
+  const supabase = createServerSupabaseClient()
+  const batchSize = options.batchSize ?? 200
+  const onDuplicate = options.onDuplicate ?? "skip"
+  const errorRows: BulkInsertErrorRow[] = []
+  let okCount = 0
+
+  const cache = new Map<string, ShelfCacheValue>()
+
+  for (const group of chunk(rows, batchSize)) {
+    const payload: BookInsertPayload[] = []
+    for (const row of group) {
+      if (!row.title) {
+        errorRows.push({ index: okCount + payload.length, message: "Missing title" })
+        continue
+      }
+      let shelfIds: ShelfCacheValue | null = null
+      try {
+        if (row.shelf) {
+          shelfIds = await ensureShelfAndLevel(supabase, row.shelf, row.level, cache)
+        }
+      } catch (error) {
+        errorRows.push({
+          index: okCount + payload.length,
+          message: error instanceof Error ? error.message : "Failed to ensure shelf/level",
+        })
+        continue
+      }
+
+      payload.push({
+        title: row.title,
+        author: row.author,
+        isbn: row.isbn,
+        cover_url: row.cover_url,
+        shelf_id: shelfIds?.shelf_id ?? null,
+        shelf_level_id: shelfIds?.shelf_level_id ?? null,
+        note: row.note,
+      })
+    }
+
+    if (!payload.length) {
+      continue
+    }
+
+    const mutation = supabase.from("books").upsert(payload, {
+      onConflict: "isbn",
+      ignoreDuplicates: onDuplicate === "skip",
+    })
+
+    const { error } = await mutation
+    if (error) {
+      payload.forEach((_, index) => {
+        errorRows.push({
+          index: okCount + index,
+          message: error.message,
+        })
+      })
+      continue
+    }
+
+    okCount += payload.length
+  }
+
+  return { okCount, errorRows }
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,0 +1,7 @@
+export function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size))
+  }
+  return batches
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,218 @@
+import { normalizeWhitespace, titleCase } from "./ui"
+
+export type BookCsvField =
+  | "title"
+  | "author"
+  | "isbn"
+  | "cover_url"
+  | "shelf"
+  | "level"
+  | "note"
+
+export type CsvHeaderMapping = Record<string, BookCsvField | null>
+
+export interface CsvPreviewRow {
+  raw: Record<string, string>
+  mapped: Partial<Record<BookCsvField, string>>
+  error?: string
+}
+
+export interface CsvPreviewResult {
+  headers: string[]
+  rows: CsvPreviewRow[]
+  errors: string[]
+}
+
+export interface PrepareBooksOptions {
+  defaultShelfId?: string
+  defaultLevelId?: string
+  titleCaseValues?: boolean
+}
+
+export interface PreparedBookRow {
+  title: string
+  author?: string | null
+  isbn?: string | null
+  cover_url?: string | null
+  shelf?: string | null
+  level?: string | null
+  note?: string | null
+}
+
+export async function readCsvFile(file: File): Promise<string> {
+  return await file.text()
+}
+
+export function autoMapHeaders(headers: string[]): CsvHeaderMapping {
+  const mapping: CsvHeaderMapping = {}
+  headers.forEach((header) => {
+    const normalized = normalizeWhitespace(header).toLowerCase()
+    if (!normalized) {
+      mapping[header] = null
+      return
+    }
+    if (/(^|\s)title(\s|$)/.test(normalized)) {
+      mapping[header] = "title"
+    } else if (/author/.test(normalized)) {
+      mapping[header] = "author"
+    } else if (/(^|\s)isbn(\s|$)/.test(normalized)) {
+      mapping[header] = "isbn"
+    } else if (/cover|image|thumb/.test(normalized)) {
+      mapping[header] = "cover_url"
+    } else if (/shelf/.test(normalized)) {
+      mapping[header] = "shelf"
+    } else if (/level|tier|row/.test(normalized)) {
+      mapping[header] = "level"
+    } else if (/note|remark|comment/.test(normalized)) {
+      mapping[header] = "note"
+    } else {
+      mapping[header] = null
+    }
+  })
+  return mapping
+}
+
+export function parseCsv(text: string): { headers: string[]; rows: Record<string, string>[] } {
+  const lines = splitCsvLines(text)
+  if (!lines.length) {
+    return { headers: [], rows: [] }
+  }
+  const headers = lines[0]
+  const rows: Record<string, string>[] = []
+  for (let i = 1; i < lines.length; i += 1) {
+    const columns = lines[i]
+    if (columns.length === 1 && columns[0] === "") {
+      continue
+    }
+    const row: Record<string, string> = {}
+    headers.forEach((header, index) => {
+      row[header] = columns[index] ?? ""
+    })
+    rows.push(row)
+  }
+  return { headers, rows }
+}
+
+function splitCsvLines(text: string): string[][] {
+  const rows: string[][] = []
+  let currentRow: string[] = []
+  let currentField = ""
+  let inQuotes = false
+  let i = 0
+
+  const pushField = () => {
+    currentRow.push(currentField)
+    currentField = ""
+  }
+
+  const pushRow = () => {
+    pushField()
+    rows.push(currentRow)
+    currentRow = []
+  }
+
+  while (i < text.length) {
+    const char = text[i]
+    if (char === "\r") {
+      i += 1
+      continue
+    }
+    if (char === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        currentField += '"'
+        i += 2
+        continue
+      }
+      inQuotes = !inQuotes
+      i += 1
+      continue
+    }
+    if (char === "," && !inQuotes) {
+      pushField()
+      i += 1
+      continue
+    }
+    if ((char === "\n" || char === "\u2028" || char === "\u2029") && !inQuotes) {
+      pushRow()
+      i += 1
+      continue
+    }
+    currentField += char
+    i += 1
+  }
+  if (currentField.length > 0 || inQuotes || currentRow.length > 0) {
+    pushRow()
+  }
+  return rows
+}
+
+export function buildPreview(
+  csvText: string,
+  mapping?: CsvHeaderMapping,
+  limit = 50,
+): CsvPreviewResult {
+  const { headers, rows } = parseCsv(csvText)
+  const activeMapping = mapping ?? autoMapHeaders(headers)
+  const previewRows: CsvPreviewRow[] = []
+  const errors: string[] = []
+
+  rows.slice(0, limit).forEach((row, index) => {
+    const mapped: Partial<Record<BookCsvField, string>> = {}
+    Object.entries(activeMapping).forEach(([header, field]) => {
+      if (!field) return
+      mapped[field] = normalizeWhitespace(row[header] ?? "")
+    })
+
+    const title = mapped.title
+    if (!title) {
+      const error = `Row ${index + 2}: Missing title`
+      previewRows.push({ raw: row, mapped, error })
+      errors.push(error)
+      return
+    }
+
+    previewRows.push({ raw: row, mapped })
+  })
+
+  return {
+    headers,
+    rows: previewRows,
+    errors,
+  }
+}
+
+export function prepareRows(
+  csvText: string,
+  mapping: CsvHeaderMapping,
+  options: PrepareBooksOptions = {},
+): PreparedBookRow[] {
+  const { headers, rows } = parseCsv(csvText)
+  const activeMapping = mapping ?? autoMapHeaders(headers)
+
+  return rows.map((row) => {
+    const mapped: Partial<Record<BookCsvField, string>> = {}
+    Object.entries(activeMapping).forEach(([header, field]) => {
+      if (!field) return
+      const value = normalizeWhitespace(row[header] ?? "")
+      if (value) {
+        mapped[field] = options.titleCaseValues && field === "title" ? titleCase(value) : value
+      }
+    })
+
+    const prepared: PreparedBookRow = {
+      title: mapped.title ?? "",
+      author: mapped.author ?? null,
+      isbn: mapped.isbn ?? null,
+      cover_url: mapped.cover_url ?? null,
+      shelf: mapped.shelf ?? null,
+      level: mapped.level ?? null,
+      note: mapped.note ?? null,
+    }
+
+    if (!prepared.title) {
+      throw new Error("CSV row is missing a title")
+    }
+
+    return prepared
+  })
+}

--- a/src/lib/shelves.ts
+++ b/src/lib/shelves.ts
@@ -1,0 +1,118 @@
+import { createServerSupabaseClient, isSupabaseConfigured } from "./supabaseClient"
+
+export interface Shelf {
+  id: string
+  name: string
+}
+
+export interface ShelfLevel {
+  id: string
+  shelf_id: string
+  name: string
+}
+
+export interface ShelfWithLevels extends Shelf {
+  levels: ShelfLevel[]
+}
+
+export async function listShelvesWithLevels(): Promise<ShelfWithLevels[]> {
+  if (!isSupabaseConfigured()) {
+    return []
+  }
+  const supabase = createServerSupabaseClient()
+  try {
+    const { data, error } = await supabase
+      .from("shelves")
+      .select("id,name,shelf_levels(id,name)")
+      .order("name", { ascending: true })
+    if (error) {
+      console.warn("Failed to fetch shelves", error)
+      return []
+    }
+    return (data ?? []).map((shelf) => ({
+      id: shelf.id,
+      name: shelf.name,
+      levels: (shelf.shelf_levels ?? []).map((level) => ({
+        id: level.id,
+        shelf_id: shelf.id,
+        name: level.name,
+      })),
+    }))
+  } catch (error) {
+    console.warn("Failed to load shelves", error)
+    return []
+  }
+}
+
+export interface EnsureShelfLevelInput {
+  shelfName: string
+  levelName?: string | null
+}
+
+export interface EnsureShelfLevelResult {
+  shelf_id: string
+  shelf_level_id?: string | null
+}
+
+export async function ensureShelfLevel(
+  input: EnsureShelfLevelInput,
+): Promise<EnsureShelfLevelResult> {
+  if (!isSupabaseConfigured()) {
+    throw new Error("Supabase is not configured")
+  }
+  const supabase = createServerSupabaseClient()
+  const { shelfName, levelName } = input
+
+  const { data: existingShelf, error: shelfError } = await supabase
+    .from("shelves")
+    .select("id")
+    .eq("name", shelfName)
+    .maybeSingle()
+  if (shelfError && shelfError.code !== "PGRST116") {
+    throw new Error(shelfError.message)
+  }
+
+  let shelfId = existingShelf?.id
+
+  if (!shelfId) {
+    const { data: createdShelf, error: createShelfError } = await supabase
+      .from("shelves")
+      .insert({ name: shelfName })
+      .select("id")
+      .single()
+    if (createShelfError) {
+      throw new Error(createShelfError.message)
+    }
+    shelfId = createdShelf.id
+  }
+
+  if (!levelName) {
+    return { shelf_id: shelfId, shelf_level_id: null }
+  }
+
+  const { data: existingLevel, error: levelError } = await supabase
+    .from("shelf_levels")
+    .select("id")
+    .eq("shelf_id", shelfId)
+    .eq("name", levelName)
+    .maybeSingle()
+  if (levelError && levelError.code !== "PGRST116") {
+    throw new Error(levelError.message)
+  }
+
+  if (existingLevel?.id) {
+    return { shelf_id: shelfId, shelf_level_id: existingLevel.id }
+  }
+
+  const { data: createdLevel, error: createLevelError } = await supabase
+    .from("shelf_levels")
+    .insert({ shelf_id: shelfId, name: levelName })
+    .select("id")
+    .single()
+
+  if (createLevelError) {
+    throw new Error(createLevelError.message)
+  }
+
+  return { shelf_id: shelfId, shelf_level_id: createdLevel.id }
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,74 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+type TokenStore = {
+  access_token?: string
+  refresh_token?: string
+}
+
+function normalizeEnv(value: string | undefined) {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.toLowerCase() === "undefined" || trimmed.toLowerCase() === "null") {
+    return undefined
+  }
+  return trimmed
+}
+
+export function isSupabaseConfigured(): boolean {
+  return Boolean(normalizeEnv(SUPABASE_URL) && normalizeEnv(SUPABASE_ANON_KEY))
+}
+
+function resolveEnv() {
+  const url = normalizeEnv(SUPABASE_URL)
+  const key = normalizeEnv(SUPABASE_ANON_KEY)
+  if (!url || !key) {
+    throw new Error("Supabase environment variables are not configured")
+  }
+  return { url, key }
+}
+
+export function createSupabaseClient(tokenStore?: TokenStore): SupabaseClient {
+  const { url, key } = resolveEnv()
+  return createClient(url, key, {
+    auth: {
+      persistSession: false,
+      detectSessionInUrl: false,
+      ...(tokenStore?.access_token
+        ? {
+            autoRefreshToken: true,
+            storage: {
+              getItem(key) {
+                if (key === "sb-access-token") {
+                  return tokenStore.access_token ?? null
+                }
+                if (key === "sb-refresh-token") {
+                  return tokenStore.refresh_token ?? null
+                }
+                return null
+              },
+              setItem() {
+                return
+              },
+              removeItem() {
+                return
+              },
+            },
+          }
+        : {}),
+    },
+  })
+}
+
+export function createServerSupabaseClient(tokenStore?: TokenStore): SupabaseClient {
+  if (tokenStore?.access_token || tokenStore?.refresh_token) {
+    return createSupabaseClient(tokenStore)
+  }
+  return createSupabaseClient()
+}
+
+export function createBrowserSupabaseClient(): SupabaseClient {
+  return createSupabaseClient()
+}

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,0 +1,32 @@
+export function formatDate(value?: string | Date | null, options?: Intl.DateTimeFormatOptions) {
+  if (!value) return "—"
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return "—"
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...options,
+  }).format(date)
+}
+
+export function truncate(value: string, length: number) {
+  if (value.length <= length) return value
+  return `${value.slice(0, Math.max(0, length - 1))}…`
+}
+
+export function normalizeWhitespace(value?: string | null) {
+  if (!value) return ""
+  return value.replace(/\s+/g, " ").trim()
+}
+
+export function titleCase(value: string) {
+  return value
+    .split(" ")
+    .map((segment) =>
+      segment.length > 2
+        ? segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase()
+        : segment.toLowerCase(),
+    )
+    .join(" ")
+}


### PR DESCRIPTION
## Summary
- add Books page shell with cards/table views and shared filters
- implement CSV import wizard with mapping, preview, and bulk insert server action
- build supporting UI components and Supabase helpers for books, shelves, and CSV parsing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79d4e6fec8329b7436307b9cb740f