### PR TITLE
Fix borrowed filter Supabase query

### DIFF
--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -102,7 +102,7 @@ export async function listBooks(params: ListBooksParams = {}): Promise<ListBooks
     if (params.status === "archived") {
       query = query.eq("is_archived", true)
     } else if (params.status === "borrowed") {
-      query = query.eq("is_archived", false).eq("loans.returned_at", null)
+      query = query.eq("is_archived", false).is("loans.returned_at", null)
     } else if (params.status === "available") {
       query = query
         .eq("is_archived", false)


### PR DESCRIPTION
## Summary
- update the borrowed filter to use Supabase's `is` comparison for null returned_at values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7c1b76c808329959b31e078458034